### PR TITLE
重构MessageManage, 将处理包的逻辑移至Command中。

### DIFF
--- a/QQ.Framework/Domains/Commands/ReceiveCommands/DefaultReceiveCommand.cs
+++ b/QQ.Framework/Domains/Commands/ReceiveCommands/DefaultReceiveCommand.cs
@@ -1,0 +1,22 @@
+﻿using QQ.Framework.Domains;
+using QQ.Framework.Packets.Receive.Message;
+
+namespace QQ.Framework.Utils
+{
+    public class DefaultReceiveCommand : ReceiveCommand
+    {
+        private Receive_Currency _packet;
+        private QQEventArgs<Receive_Currency> _event_args;
+
+        public DefaultReceiveCommand(byte[] data, QQClient client) : base(data, client)
+        {
+            _packet = new Receive_Currency(data, client.QQUser);
+            _event_args = new QQEventArgs<Receive_Currency>(client, _packet);
+        }
+
+        public override void Receive()
+        {
+            _client.OnReceive_Currency(_event_args);
+        }
+    }
+}

--- a/QQ.Framework/Domains/Commands/ReceiveCommands/Login/LoginPingCommand.cs
+++ b/QQ.Framework/Domains/Commands/ReceiveCommands/Login/LoginPingCommand.cs
@@ -1,0 +1,34 @@
+﻿    using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+    using QQ.Framework.Packets.Receive.Login;
+
+namespace QQ.Framework.Domains.Commands.ReceiveCommands.Login
+{
+    [ReceivePackageCommand(QQCommand.Login0x0825)]
+    public class LoginPingCommand : ReceiveCommand
+    {
+        private Receive_0x0825 _packet;
+        private QQEventArgs<Receive_0x0825> _event_args;
+
+        public LoginPingCommand(byte[] data, QQClient client) : base(data, client)
+        {
+            _packet = new Receive_0x0825(data, client.QQUser);
+            _event_args = new QQEventArgs<Receive_0x0825>(client, _packet);
+        }
+
+        public override void Receive()
+        {
+            if (_packet.DataHead == 0xFE)
+            {
+                _client.OnReceive_0x0825Redirect(_event_args);
+            }
+            else
+            {
+                _client.OnReceive_0x0825(_event_args);
+            }
+        }
+    }
+}

--- a/QQ.Framework/Domains/IPacket.cs
+++ b/QQ.Framework/Domains/IPacket.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QQ.Framework.Domains
+{
+    public interface IPacket
+    {
+    }
+}

--- a/QQ.Framework/Domains/ReceiveCommand.cs
+++ b/QQ.Framework/Domains/ReceiveCommand.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using QQ.Framework.Packets;
+
+namespace QQ.Framework.Domains
+{
+    public abstract class ReceiveCommand
+    {
+        protected readonly QQClient _client;
+
+        public ReceiveCommand(byte[] data, QQClient client)
+        {
+            _client = client;
+        }
+
+        /// <summary>
+        /// 接收包的处理逻辑在此处完成
+        /// </summary>
+        public abstract void Receive();
+    }
+}

--- a/QQ.Framework/Domains/ReceivePackageCommand.cs
+++ b/QQ.Framework/Domains/ReceivePackageCommand.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QQ.Framework.Domains
+{
+    public class ReceivePackageCommand : Attribute
+    {
+        public QQCommand Command { get; }
+
+        public ReceivePackageCommand(QQCommand command)
+        {
+            Command = command;
+        }
+    }
+}

--- a/QQ.Framework/QQ.Framework.csproj
+++ b/QQ.Framework/QQ.Framework.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -37,6 +37,9 @@
   <ItemGroup>
     <Reference Include="Ionic.Zlib, Version=1.9.1.5, Culture=neutral, PublicKeyToken=edbe51ad942a3f5c, processorArchitecture=MSIL">
       <HintPath>..\packages\Ionic.Zlib.1.9.1.5\lib\Ionic.Zlib.dll</HintPath>
+    </Reference>
+    <Reference Include="Ionic.Zlib.Core">
+      <HintPath>C:\Users\63207\.nuget\packages\ionic.zlib.core\1.0.0\lib\netstandard2.0\Ionic.Zlib.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -107,6 +110,11 @@
     <Compile Include="..\QQ.Framework\Utils\ImageHelper.cs" />
     <Compile Include="..\QQ.Framework\Utils\QQTea.cs" />
     <Compile Include="..\QQ.Framework\Utils\Util.cs" />
+    <Compile Include="Domains\Commands\ReceiveCommands\DefaultReceiveCommand.cs" />
+    <Compile Include="Domains\Commands\ReceiveCommands\Login\LoginPingCommand.cs" />
+    <Compile Include="Domains\IPacket.cs" />
+    <Compile Include="Domains\ReceiveCommand.cs" />
+    <Compile Include="Domains\ReceivePackageCommand.cs" />
     <Compile Include="Packets\PCTLV\BaseTLV.cs" />
     <Compile Include="Packets\PCTLV\TLV_0004.cs" />
     <Compile Include="Packets\PCTLV\TLV_0005.cs" />
@@ -149,10 +157,14 @@
     <Compile Include="Packets\PCTLV\TLV_0312.cs" />
     <Compile Include="Packets\PCTLV\TLV_0313.cs" />
     <Compile Include="TXProtocol.cs" />
+    <Compile Include="Utils\DispatchPacketToCommand.cs" />
     <Compile Include="Utils\GZipByteArray.cs" />
     <Compile Include="Utils\StringHandlingPackets.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Folder Include="Domains\Commands\ReceiveCommands\Data\" />
+    <Folder Include="Domains\Commands\ReceiveCommands\Interactive\" />
+    <Folder Include="Domains\Commands\ReceiveCommands\Message\" />
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>

--- a/QQ.Framework/QQ.Framework.csproj.user
+++ b/QQ.Framework/QQ.Framework.csproj.user
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectView>ProjectFiles</ProjectView>

--- a/QQ.Framework/Utils/DispatchPacketToCommand.cs
+++ b/QQ.Framework/Utils/DispatchPacketToCommand.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using QQ.Framework.Domains;
+
+namespace QQ.Framework.Utils
+{
+    public class DispatchPacketToCommand
+    {
+        private readonly byte[] _data;
+        private readonly QQClient _client;
+
+        protected DispatchPacketToCommand(byte[] data, QQClient client)
+        {
+            _data = data;
+            _client = client;
+        }
+
+        public static DispatchPacketToCommand of(byte[] data, QQClient client)
+        {
+            return new DispatchPacketToCommand(data, client);
+        }
+
+        public ReceiveCommand dispatch_receive_packet(QQCommand command)
+        {
+            var types = Assembly.GetExecutingAssembly().GetTypes();
+            foreach (var type in types)
+            {
+                var attributes = type.GetCustomAttributes();
+                if (!attributes.Any(attr => attr is ReceivePackageCommand)) continue;
+
+                var attribute = attributes.First(attr => attr is ReceivePackageCommand) as ReceivePackageCommand;
+                if (attribute.Command == command)
+                {
+                    var receive_packet = Activator.CreateInstance(type, new object[] { _data, _client }) as ReceiveCommand;
+                    return receive_packet;
+                }
+            }
+            return new DefaultReceiveCommand(_data, _client);
+        }
+    }
+}

--- a/QQ.FrameworkTest/Domains/Commands/ReceiveCommands/Login/LoginPingPacketCommandSpecs.cs
+++ b/QQ.FrameworkTest/Domains/Commands/ReceiveCommands/Login/LoginPingPacketCommandSpecs.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Machine.Specifications;
+using QQ.Framework;
+using QQ.Framework.Domains;
+using QQ.Framework.Domains.Commands.ReceiveCommands.Login;
+using QQ.Framework.Utils;
+
+namespace QQ.FrameworkTest.Domains.Commands.ReceiveCommands.Login
+{
+    public class LoginPingPacketCommandSpecs
+    {
+        private Establish that =
+            () =>
+            {
+                var user = new QQUser(Int32.MaxValue, "");
+                subject = DispatchPacketToCommand.of(new byte[] { }, new QQClient() { QQUser = user });
+                command = QQCommand.Login0x0825;
+            };
+
+        private Because of =
+            () =>
+            {
+                receive_command = subject.dispatch_receive_packet(command);
+            };
+
+        private It receive_command_should_a_LoginPingCommand =
+            () =>
+            {
+                (receive_command is LoginPingCommand).ShouldBeTrue();
+            };
+
+        private static DispatchPacketToCommand subject;
+        private static QQCommand command;
+        private static ReceiveCommand receive_command;
+    }
+}

--- a/QQ.FrameworkTest/QQ.FrameworkTest.csproj
+++ b/QQ.FrameworkTest/QQ.FrameworkTest.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\MSTest.TestAdapter.1.2.1\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.1\build\net45\MSTest.TestAdapter.props')" />
   <PropertyGroup>
@@ -38,6 +38,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Machine.Specifications, Version=0.11.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Machine.Specifications.0.11.0\lib\net45\Machine.Specifications.dll</HintPath>
+    </Reference>
+    <Reference Include="Machine.Specifications.Should, Version=0.11.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Machine.Specifications.Should.0.11.0\lib\net45\Machine.Specifications.Should.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.1.2.1\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
@@ -46,8 +52,13 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Remoting" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Xml.Serialization" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Domains\Commands\ReceiveCommands\Login\LoginPingPacketCommandSpecs.cs" />
     <Compile Include="GZipByteArrayTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -59,6 +70,11 @@
       <Project>{155BC652-D6ED-4DBF-82D2-A9188CB57C52}</Project>
       <Name>QQ.Framework</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Domains\Commands\ReceiveCommands\Data\" />
+    <Folder Include="Domains\Commands\ReceiveCommands\Interactive\" />
+    <Folder Include="Domains\Commands\ReceiveCommands\Message\" />
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/QQ.FrameworkTest/packages.config
+++ b/QQ.FrameworkTest/packages.config
@@ -1,6 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="MSTest.TestAdapter" version="1.2.1" targetFramework="net461" />
-    <package id="MSTest.TestFramework" version="1.2.1" targetFramework="net461" />
+  <package id="Machine.Specifications" version="0.11.0" targetFramework="net461" />
+  <package id="Machine.Specifications.Should" version="0.11.0" targetFramework="net461" />
+  <package id="MSTest.TestAdapter" version="1.2.1" targetFramework="net461" />
+  <package id="MSTest.TestFramework" version="1.2.1" targetFramework="net461" />
 </packages>

--- a/QQLoginTest/QQLoginTest.csproj
+++ b/QQLoginTest/QQLoginTest.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -49,7 +49,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="MyUser.cs" />
+    <Compile Include="MyUsers.cs" />
     <Compile Include="Program.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@ MyUser.cs为本人扩展用户名和密码这里不做上传
 
 源码仅供参考，欢迎吐槽
 ------------------------------------------
+#### 2018-9-3 
+重构MessageManage,将对包的处理逻辑移至Command中, 对应项目里Domains/Commands文件夹下的内容。
+如何添加一个Command: 
+
+1. 首先在`Domains/Commands`下对应目录新建Command, 继承`ReceiveCommand`/`SendCommand`。
+2. 在新建的Commad上添加`[ReceivePackageCommand(QQCommand.具体你的包名)]`, 这个属性就是包分发的依据，你填写的是什么Command,那么当接收到这个包的时候就会分发给这个类来处理。
+3. 构造函数中实例化对应`Packet`和`QQQEventArgs`。
+4. 在`Receive`方法中写你的具体逻辑即可。
+
+通过以上四步, 就可以对一个包的解析啦，不用去修改MessageManage，避免在多人修改时容易产生冲突导致, 也更方便的查看处理包的具体逻辑。
+
+Tips: 可以参考`Domains/Commands/ReceiveCommands/LoginPingCommand`的写法, 这个是对于Login0x0825包的处理。
+
 #### 2018-9-1
 添加XML消息发送  
 移除ByteBuffer，使用BinaryReader和BinaryWriter进行读写。  


### PR DESCRIPTION
重构MessageManage, 将Switch语句移除。
在面对包类增多时，可以良好的应对，并且不显得代码冗余。
将各包的处理逻辑移至单独类，可以多人同时解包而不冲突。

望采纳，谢谢。
by Expectation.