### PR TITLE
 将发送信息改为富文本

### DIFF
--- a/QQ.Framework/Domains/Commands/ReceiveCommands/Data/GetQQLevelCommand.cs
+++ b/QQ.Framework/Domains/Commands/ReceiveCommands/Data/GetQQLevelCommand.cs
@@ -11,7 +11,8 @@ namespace QQ.Framework.Domains.Commands.ReceiveCommands.Data
         /// <summary>
         ///     获取QQ等级
         /// </summary>
-        public GetQQLevelCommand(byte[] data, SocketService service, ServerMessageSubject transponder, QQUser user) : base(data, service, transponder, user)
+        public GetQQLevelCommand(byte[] data, SocketService service, ServerMessageSubject transponder, QQUser user) :
+            base(data, service, transponder, user)
         {
             _packet = new Receive_0x005C(data, _user);
             _event_args = new QQEventArgs<Receive_0x005C>(_service, _user, _packet);

--- a/QQ.Framework/Domains/Commands/ReceiveCommands/Data/KeyQueryCommand.cs
+++ b/QQ.Framework/Domains/Commands/ReceiveCommands/Data/KeyQueryCommand.cs
@@ -11,7 +11,8 @@ namespace QQ.Framework.Domains.Commands.ReceiveCommands.Data
         /// <summary>
         ///     Key查询
         /// </summary>
-        public KeyQueryCommand(byte[] data, SocketService service, ServerMessageSubject transponder, QQUser user) : base(data, service, transponder, user)
+        public KeyQueryCommand(byte[] data, SocketService service, ServerMessageSubject transponder, QQUser user) :
+            base(data, service, transponder, user)
         {
             _packet = new Receive_0x001D(data, _user);
             _event_args = new QQEventArgs<Receive_0x001D>(_service, _user, _packet);

--- a/QQ.Framework/Domains/Commands/ReceiveCommands/DefaultReceiveCommand.cs
+++ b/QQ.Framework/Domains/Commands/ReceiveCommands/DefaultReceiveCommand.cs
@@ -4,7 +4,8 @@ namespace QQ.Framework.Domains.Commands.ReceiveCommands
 {
     public class DefaultReceiveCommand : ReceiveCommand<Receive_Currency>
     {
-        public DefaultReceiveCommand(byte[] data, SocketService service, ServerMessageSubject transponder, QQUser user) : base(data, service, transponder, user)
+        public DefaultReceiveCommand(byte[] data, SocketService service, ServerMessageSubject transponder, QQUser user)
+            : base(data, service, transponder, user)
         {
             _packet = new Receive_Currency(data, _user);
             _event_args = new QQEventArgs<Receive_Currency>(_service, _user, _packet);

--- a/QQ.Framework/Domains/Commands/ReceiveCommands/Login/GetTGTGTCommand.cs
+++ b/QQ.Framework/Domains/Commands/ReceiveCommands/Login/GetTGTGTCommand.cs
@@ -5,7 +5,8 @@ namespace QQ.Framework.Domains.Commands.ReceiveCommands.Login
     [ReceivePacketCommand(QQCommand.Login0x0836)]
     public class GetTGTGTCommand : ReceiveCommand<Receive_0x0836>
     {
-        public GetTGTGTCommand(byte[] data, SocketService service, ServerMessageSubject transponder, QQUser user) : base(data, service, transponder, user)
+        public GetTGTGTCommand(byte[] data, SocketService service, ServerMessageSubject transponder, QQUser user) :
+            base(data, service, transponder, user)
         {
             _packet = new Receive_0x0836(data, _user);
             _event_args = new QQEventArgs<Receive_0x0836>(_service, _user, _packet);

--- a/QQ.Framework/Domains/Commands/ReceiveCommands/Login/LoginPingCommand.cs
+++ b/QQ.Framework/Domains/Commands/ReceiveCommands/Login/LoginPingCommand.cs
@@ -5,7 +5,8 @@ namespace QQ.Framework.Domains.Commands.ReceiveCommands.Login
     [ReceivePacketCommand(QQCommand.Login0x0825)]
     public class LoginPingCommand : ReceiveCommand<Receive_0x0825>
     {
-        public LoginPingCommand(byte[] data, SocketService service, ServerMessageSubject transponder, QQUser user) : base(data, service, transponder, user)
+        public LoginPingCommand(byte[] data, SocketService service, ServerMessageSubject transponder, QQUser user) :
+            base(data, service, transponder, user)
         {
             _packet = new Receive_0x0825(data, _user);
             _event_args = new QQEventArgs<Receive_0x0825>(_service, _user, _packet);

--- a/QQ.Framework/Domains/Commands/ReceiveCommands/Login/OnLineStateCommand.cs
+++ b/QQ.Framework/Domains/Commands/ReceiveCommands/Login/OnLineStateCommand.cs
@@ -5,7 +5,8 @@ namespace QQ.Framework.Domains.Commands.ReceiveCommands.Login
     [ReceivePacketCommand(QQCommand.Login0x00EC)]
     public class OnLineStateCommand : ReceiveCommand<Receive_0x00EC>
     {
-        public OnLineStateCommand(byte[] data, SocketService service, ServerMessageSubject transponder, QQUser user) : base(data, service, transponder, user)
+        public OnLineStateCommand(byte[] data, SocketService service, ServerMessageSubject transponder, QQUser user) :
+            base(data, service, transponder, user)
         {
             _packet = new Receive_0x00EC(data, _user);
             _event_args = new QQEventArgs<Receive_0x00EC>(_service, _user, _packet);

--- a/QQ.Framework/Domains/Commands/ReceiveCommands/Login/PreLoginCommand.cs
+++ b/QQ.Framework/Domains/Commands/ReceiveCommands/Login/PreLoginCommand.cs
@@ -5,7 +5,8 @@ namespace QQ.Framework.Domains.Commands.ReceiveCommands.Login
     [ReceivePacketCommand(QQCommand.Login0x0828)]
     public class PreLoginCommand : ReceiveCommand<Receive_0x0828>
     {
-        public PreLoginCommand(byte[] data, SocketService service, ServerMessageSubject transponder, QQUser user) : base(data, service, transponder, user)
+        public PreLoginCommand(byte[] data, SocketService service, ServerMessageSubject transponder, QQUser user) :
+            base(data, service, transponder, user)
         {
             _packet = new Receive_0x0828(data, _user);
             _event_args = new QQEventArgs<Receive_0x0828>(_service, _user, _packet);

--- a/QQ.Framework/Domains/Commands/ReceiveCommands/Login/VerifyCodeCommand.cs
+++ b/QQ.Framework/Domains/Commands/ReceiveCommands/Login/VerifyCodeCommand.cs
@@ -5,7 +5,8 @@ namespace QQ.Framework.Domains.Commands.ReceiveCommands.Login
     [ReceivePacketCommand(QQCommand.Login0x00BA)]
     public class VerifyCodeCommand : ReceiveCommand<Receive_0x00BA>
     {
-        public VerifyCodeCommand(byte[] data, SocketService service, ServerMessageSubject transponder, QQUser user) : base(data, service, transponder, user)
+        public VerifyCodeCommand(byte[] data, SocketService service, ServerMessageSubject transponder, QQUser user) :
+            base(data, service, transponder, user)
         {
             _packet = new Receive_0x00BA(data, _user);
             _event_args = new QQEventArgs<Receive_0x00BA>(_service, _user, _packet);

--- a/QQ.Framework/Domains/Commands/ReceiveCommands/Message/KeepAliveCommand.cs
+++ b/QQ.Framework/Domains/Commands/ReceiveCommands/Message/KeepAliveCommand.cs
@@ -11,7 +11,8 @@ namespace QQ.Framework.Domains.Commands.ReceiveCommands.Message
         /// <summary>
         ///     KeepAlive（心跳）
         /// </summary>
-        public KeepAliveCommand(byte[] data, SocketService service, ServerMessageSubject transponder, QQUser user) : base(data, service, transponder, user)
+        public KeepAliveCommand(byte[] data, SocketService service, ServerMessageSubject transponder, QQUser user) :
+            base(data, service, transponder, user)
         {
             _packet = new Receive_0x0058(data, _user);
             _event_args = new QQEventArgs<Receive_0x0058>(_service, _user, _packet);

--- a/QQ.Framework/Domains/Commands/ReceiveCommands/Message/ReceiveGroupSystemMessagesCommand.cs
+++ b/QQ.Framework/Domains/Commands/ReceiveCommands/Message/ReceiveGroupSystemMessagesCommand.cs
@@ -11,7 +11,8 @@ namespace QQ.Framework.Domains.Commands.ReceiveCommands.Message
         /// <summary>
         ///     收到群/系统消息
         /// </summary>
-        public ReceiveGroupSystemMessagesCommand(byte[] data, SocketService service, ServerMessageSubject transponder, QQUser user) : base(data, service, transponder, user)
+        public ReceiveGroupSystemMessagesCommand(byte[] data, SocketService service, ServerMessageSubject transponder,
+            QQUser user) : base(data, service, transponder, user)
         {
             _packet = new Receive_0x0017(data, _user);
             _event_args = new QQEventArgs<Receive_0x0017>(_service, _user, _packet);

--- a/QQ.Framework/Domains/Commands/ReceiveCommands/Message/ReceiveQQFriendMessagesCommand.cs
+++ b/QQ.Framework/Domains/Commands/ReceiveCommands/Message/ReceiveQQFriendMessagesCommand.cs
@@ -8,7 +8,8 @@ namespace QQ.Framework.Domains.Commands.ReceiveCommands.Message
     [ReceivePacketCommand(QQCommand.Message0x00CE)]
     public class ReceiveQQFriendMessagesCommand : ReceiveCommand<Receive_0x00CE>
     {
-        public ReceiveQQFriendMessagesCommand(byte[] data, SocketService service, ServerMessageSubject transponder, QQUser user) : base(data, service, transponder, user)
+        public ReceiveQQFriendMessagesCommand(byte[] data, SocketService service, ServerMessageSubject transponder,
+            QQUser user) : base(data, service, transponder, user)
         {
             _packet = new Receive_0x00CE(data, _user);
             _event_args = new QQEventArgs<Receive_0x00CE>(_service, _user, _packet);

--- a/QQ.Framework/Domains/Commands/ReceiveCommands/Message/SendingGroupSystemMessagesCommand.cs
+++ b/QQ.Framework/Domains/Commands/ReceiveCommands/Message/SendingGroupSystemMessagesCommand.cs
@@ -8,7 +8,8 @@ namespace QQ.Framework.Domains.Commands.ReceiveCommands.Message
     [ReceivePacketCommand(QQCommand.Message0x0002)]
     public class SendingGroupSystemMessagesCommand : ReceiveCommand<Receive_0x0002>
     {
-        public SendingGroupSystemMessagesCommand(byte[] data, SocketService service, ServerMessageSubject transponder, QQUser user) : base(data, service, transponder, user)
+        public SendingGroupSystemMessagesCommand(byte[] data, SocketService service, ServerMessageSubject transponder,
+            QQUser user) : base(data, service, transponder, user)
         {
             _packet = new Receive_0x0002(data, _user);
             _event_args = new QQEventArgs<Receive_0x0002>(_service, _user, _packet);

--- a/QQ.Framework/Domains/Commands/ReceiveCommands/Message/SendingQQMessagesCommand.cs
+++ b/QQ.Framework/Domains/Commands/ReceiveCommands/Message/SendingQQMessagesCommand.cs
@@ -8,7 +8,8 @@ namespace QQ.Framework.Domains.Commands.ReceiveCommands.Message
     [ReceivePacketCommand(QQCommand.Message0x00CD)]
     public class SendingQQMessagesCommand : ReceiveCommand<Receive_0x00CD>
     {
-        public SendingQQMessagesCommand(byte[] data, SocketService service, ServerMessageSubject transponder, QQUser user) : base(data, service, transponder, user)
+        public SendingQQMessagesCommand(byte[] data, SocketService service, ServerMessageSubject transponder,
+            QQUser user) : base(data, service, transponder, user)
         {
             _packet = new Receive_0x00CD(data, _user);
             _event_args = new QQEventArgs<Receive_0x00CD>(_service, _user, _packet);

--- a/QQ.Framework/Domains/Commands/ResponseCommands/Message/ResponseReceiveFriendMessageCommand.cs
+++ b/QQ.Framework/Domains/Commands/ResponseCommands/Message/ResponseReceiveFriendMessageCommand.cs
@@ -17,9 +17,9 @@ namespace QQ.Framework.Domains.Commands.ResponseCommands.Message
 
         public override void Process()
         {
-            if (!string.IsNullOrEmpty(_packet.Message))
+            if (!string.IsNullOrEmpty(_packet.Message.ToString()))
             {
-                if (!QQGlobal.DebugLog && _packet.Message.Count(c => c == '\0') > 5)
+                if (!QQGlobal.DebugLog && _packet.Message.ToString().Count(c => c == '\0') > 5)
                 {
                     _service.MessageLog($"收到好友{_packet.FromQQ}的乱码消息。");
                     //return;

--- a/QQ.Framework/Domains/CustomRoBot.cs
+++ b/QQ.Framework/Domains/CustomRoBot.cs
@@ -1,4 +1,5 @@
 ﻿using QQ.Framework.Domains.Observers;
+using QQ.Framework.Utils;
 
 namespace QQ.Framework.Domains
 {
@@ -32,7 +33,7 @@ namespace QQ.Framework.Domains
             _transponder.AddCustomRoBot(this);
         }
 
-        public abstract void ReceiveFriendMessage(long friendNumber, string content);
-        public abstract void ReceiveGroupMessage(long groupNumber, long fromNumber, string content);
+        public abstract void ReceiveFriendMessage(long friendNumber, Richtext content);
+        public abstract void ReceiveGroupMessage(long groupNumber, long fromNumber, Richtext content);
     }
 }

--- a/QQ.Framework/Domains/ResponsiveMessages.cs
+++ b/QQ.Framework/Domains/ResponsiveMessages.cs
@@ -1,4 +1,6 @@
-﻿namespace QQ.Framework.Domains
+﻿using QQ.Framework.Utils;
+
+namespace QQ.Framework.Domains
 {
     /// <summary>
     ///     可响应的消息事件列表
@@ -10,7 +12,7 @@
         /// </summary>
         /// <param name="friendNumber">好友qq</param>
         /// <param name="content">内容</param>
-        void ReceiveFriendMessage(long friendNumber, string content);
+        void ReceiveFriendMessage(long friendNumber, Richtext content);
 
         /// <summary>
         ///     收到群组消息
@@ -18,6 +20,6 @@
         /// <param name="groupNumber">QQ群号</param>
         /// <param name="fromNumber">发言者QQ</param>
         /// <param name="content">内容</param>
-        void ReceiveGroupMessage(long groupNumber, long fromNumber, string content);
+        void ReceiveGroupMessage(long groupNumber, long fromNumber, Richtext content);
     }
 }

--- a/QQ.Framework/Domains/SendMessageService.cs
+++ b/QQ.Framework/Domains/SendMessageService.cs
@@ -1,4 +1,6 @@
-﻿namespace QQ.Framework.Domains
+﻿using QQ.Framework.Utils;
+
+namespace QQ.Framework.Domains
 {
     /// <summary>
     ///     发送消息服务
@@ -10,21 +12,13 @@
         /// </summary>
         /// <param name="friendNumber">好友QQ</param>
         /// <param name="content">内容</param>
-        void SendToFriend(long friendNumber, string content);
+        void SendToFriend(long friendNumber, Richtext content);
 
         /// <summary>
         ///     发送群消息
         /// </summary>
         /// <param name="groupNumber">QQ群号</param>
         /// <param name="content">内容</param>
-        void SendToGroup(long groupNumber, string content);
-
-        /// <summary>
-        ///     发送群消息时@某些人
-        /// </summary>
-        /// <param name="groupNumber">QQ群号</param>
-        /// <param name="content">内容</param>
-        /// <param name="atList">@列表</param>
-        void SendToGroupWithAt(long groupNumber, string content, params long[] atList);
+        void SendToGroup(long groupNumber, Richtext content);
     }
 }

--- a/QQ.Framework/Domains/SendMessageServiceImpl.cs
+++ b/QQ.Framework/Domains/SendMessageServiceImpl.cs
@@ -1,6 +1,4 @@
-﻿using QQ.Framework.Packets.Send.Login;
-using System;
-using QQ.Framework.Packets.Send.Message;
+﻿using QQ.Framework.Packets.Send.Message;
 using QQ.Framework.Utils;
 
 namespace QQ.Framework.Domains

--- a/QQ.Framework/Domains/SendMessageServiceImpl.cs
+++ b/QQ.Framework/Domains/SendMessageServiceImpl.cs
@@ -1,29 +1,29 @@
 ﻿using QQ.Framework.Packets.Send.Login;
+using System;
+using QQ.Framework.Packets.Send.Message;
+using QQ.Framework.Utils;
 
 namespace QQ.Framework.Domains
 {
     public class SendMessageServiceImpl : SendMessageService
     {
         private readonly SocketService _socketService;
+        private readonly QQUser _user;
 
-        public SendMessageServiceImpl(SocketService socketService)
+        public SendMessageServiceImpl(SocketService socketService, QQUser user)
         {
             _socketService = socketService;
+            _user = user;
         }
 
-        public void SendToFriend(long friendNumber, string content)
+        public void SendToFriend(long friendNumber, Richtext content)
         {
-            throw new System.NotImplementedException();
+            _socketService.Send(new Send_0x00CD(_user, content, MessageType.Normal, friendNumber));
         }
 
-        public void SendToGroup(long groupNumber, string content)
+        public void SendToGroup(long groupNumber, Richtext content)
         {
-            throw new System.NotImplementedException();
-        }
-
-        public void SendToGroupWithAt(long groupNumber, string content, params long[] atList)
-        {
-            throw new System.NotImplementedException();
+            _socketService.Send(new Send_0x0002(_user, content, MessageType.Normal, groupNumber));
         }
     }
 }

--- a/QQ.Framework/Domains/SocketServiceImpl.cs
+++ b/QQ.Framework/Domains/SocketServiceImpl.cs
@@ -15,7 +15,7 @@ namespace QQ.Framework.Domains
         /// <summary>
         ///     Socket连接
         /// </summary>
-        private Socket _server;
+        private readonly Socket _server;
 
         /// <summary>
         ///     服务器地址
@@ -25,7 +25,8 @@ namespace QQ.Framework.Domains
         /// <summary>
         ///     登录端口
         /// </summary>
-        private int _port = 8000;
+        private readonly int _port = 8000;
+
         private EndPoint _point;
 
 
@@ -43,11 +44,11 @@ namespace QQ.Framework.Domains
             var buffer = new byte[QQGlobal.QQ_PACKET_MAX_SIZE];
             var len = _server.ReceiveFrom(buffer, ref end_point);
 
-            return new ReceiveData()
+            return new ReceiveData
             {
                 Data = buffer,
                 DataLength = len,
-                From = end_point,
+                From = end_point
             };
         }
 

--- a/QQ.Framework/Domains/Transponder.cs
+++ b/QQ.Framework/Domains/Transponder.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using QQ.Framework.Domains.Observers;
+using QQ.Framework.Utils;
 
 namespace QQ.Framework.Domains
 {
@@ -18,7 +19,7 @@ namespace QQ.Framework.Domains
             _robots = new List<ServerMessageObserver>();
         }
 
-        public void ReceiveFriendMessage(long friendNumber, string content)
+        public void ReceiveFriendMessage(long friendNumber, Richtext content)
         {
             foreach (var robot in _robots)
             {
@@ -26,7 +27,7 @@ namespace QQ.Framework.Domains
             }
         }
 
-        public void ReceiveGroupMessage(long groupNumber, long fromNumber, string content)
+        public void ReceiveGroupMessage(long groupNumber, long fromNumber, Richtext content)
         {
             foreach (var robot in _robots)
             {

--- a/QQ.Framework/Events/QQEventArgs.cs
+++ b/QQ.Framework/Events/QQEventArgs.cs
@@ -7,13 +7,10 @@ namespace QQ.Framework
     public class QQEventArgs<R> : EventArgs
         where R : ReceivePacket
     {
-        private readonly SocketService _service;
-        private readonly QQUser _user;
-
         public QQEventArgs(SocketService service, QQUser user, R receivePacket)
         {
-            _service = service;
-            _user = user;
+            Service = service;
+            User = user;
             ReceivePacket = receivePacket;
         }
 
@@ -25,11 +22,11 @@ namespace QQ.Framework
         /// <summary>
         ///     Socket服务
         /// </summary>
-        public SocketService Service { get { return _service; } }
+        public SocketService Service { get; }
 
         /// <summary>
         ///     账号信息
         /// </summary>
-        public QQUser User { get { return _user; } }
+        public QQUser User { get; }
     }
 }

--- a/QQ.Framework/Packets/PCTLV/TLV_0104.cs
+++ b/QQ.Framework/Packets/PCTLV/TLV_0104.cs
@@ -61,7 +61,9 @@ namespace Struggle.Framework.PCQQ.PCLogin.PCPacket.PCTLV
                         Directory.CreateDirectory(directory);
                     }
 
-                    var fs = Next == 0x00 ? new FileStream(filename, FileMode.Create, FileAccess.ReadWrite, FileShare.Read) : new FileStream(filename, FileMode.Append, FileAccess.Write, FileShare.Read);
+                    var fs = Next == 0x00
+                        ? new FileStream(filename, FileMode.Create, FileAccess.ReadWrite, FileShare.Read)
+                        : new FileStream(filename, FileMode.Append, FileAccess.Write, FileShare.Read);
 
                     //fs.Seek(0, SeekOrigin.End);
                     fs.Write(buffer, 0, buffer.Length);

--- a/QQ.Framework/Packets/Receive/Message/Receive_0x00CE.cs
+++ b/QQ.Framework/Packets/Receive/Message/Receive_0x00CE.cs
@@ -44,7 +44,7 @@ namespace QQ.Framework.Packets.Receive.Message
         /// <summary>
         ///     消息内容
         /// </summary>
-        public string Message { get; set; }
+        public Richtext Message { get; set; }
 
         protected override void ParseBody()
         {
@@ -71,7 +71,8 @@ namespace QQ.Framework.Packets.Receive.Message
             FontStyle = reader.ReadBytes(reader.BEReadChar());
             reader.ReadBytes(6);
             MessageLength = reader.BEReadChar();
-            Message = Encoding.UTF8.GetString(reader.ReadBytes(MessageLength));
+            // TODO: 解析富文本
+            Message = Richtext.FromLiteral(Encoding.UTF8.GetString(reader.ReadBytes(MessageLength)));
             reader.ReadBytes(22);
         }
     }

--- a/QQ.Framework/Packets/Receive/Message/Receive_0x0352.cs
+++ b/QQ.Framework/Packets/Receive/Message/Receive_0x0352.cs
@@ -1,12 +1,10 @@
 namespace QQ.Framework.Packets.Receive.Message
 {
     /// <summary>
-    /// 
     /// </summary>
     public class Receive_0x0352 : ReceivePacket
     {
         /// <summary>
-        ///     
         /// </summary>
         public Receive_0x0352(byte[] byteBuffer, QQUser User)
             : base(byteBuffer, User, User.QQ_SessionKey)

--- a/QQ.Framework/Packets/Send/Message/Send_0x0002.cs
+++ b/QQ.Framework/Packets/Send/Message/Send_0x0002.cs
@@ -14,16 +14,16 @@ namespace QQ.Framework.Packets.Send.Message
     {
         private readonly long _group;
 
-        private byte _packetCount = 1;
+        private readonly byte _packetCount = 1;
         private byte _packetIndex;
 
-        public Send_0x0002(QQUser User, string Message, MessageType messageType, long Group)
+        public Send_0x0002(QQUser User, Richtext Message, MessageType messageType, long Group)
             : base(User)
         {
             Sequence = GetNextSeq();
             _secretKey = user.QQ_SessionKey;
             Command = QQCommand.Message0x0002;
-            _message = Encoding.UTF8.GetBytes(Message);
+            _message = Message;
             _messageType = messageType;
             _group = Group;
         }
@@ -33,7 +33,7 @@ namespace QQ.Framework.Packets.Send.Message
         /// </summary>
         public MessageType _messageType { get; set; }
 
-        private byte[] _message { get; set; }
+        private Richtext _message { get; }
 
         protected override void PutHeader()
         {
@@ -48,113 +48,154 @@ namespace QQ.Framework.Packets.Send.Message
         {
             var _DateTime = Util.GetTimeSeconds(DateTime.Now);
             var group = GroupToGid(_group);
-            if (_messageType.HasFlag(MessageType.Xml))
+            foreach (var snippet in _message.Snippets)
             {
-                bodyWriter.Write((byte) 0x2A);
-                bodyWriter.BEWrite(group);
-                var compressMsg = GZipByteArray.CompressBytes(Encoding.UTF8.GetString(_message));
-                bodyWriter.BEWrite((ushort) (compressMsg.Length + 64));
-                bodyWriter.Write(new byte[]
+                switch (snippet.Type)
                 {
-                    0x00, 0x01, _packetCount, _packetIndex, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x4D, 0x53, 0x47, 0x00,
-                    0x00, 0x00, 0x00, 0x00
-                });
-                bodyWriter.Write(SendXML(_DateTime, compressMsg));
-            }
-            else if (_messageType.HasFlag(MessageType.Picture))
-            {
-                HttpUpLoadGroupImg(_group, user.Ukey, Encoding.UTF8.GetString(_message));
-                bodyWriter.Write((byte) 0x2A);
-                bodyWriter.BEWrite(group);
-                var Guid = Encoding.UTF8.GetBytes(Util.GetMD5ToGuidHashFromFile(Encoding.UTF8.GetString(_message)));
-                bodyWriter.Write(new byte[]
-                {
-                    0x00, 0x01, _packetCount, _packetIndex, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x4D, 0x53, 0x47, 0x00,
-                    0x00, 0x00, 0x00, 0x00
-                });
-                bodyWriter.BEWrite(_DateTime);
-                bodyWriter.Write(Util.RandomKey(4));
-                bodyWriter.Write(new byte[] {0x00, 0x00, 0x00, 0x00, 0x09, 0x00, 0x86, 0x00});
-                bodyWriter.Write(new byte[] {0xE5, 0xBE, 0xAE, 0xE8, 0xBD, 0xAF, 0xE9, 0x9B, 0x85, 0xE9, 0xBB, 0x91});
-                bodyWriter.Write(new byte[] {0x00, 0x00, 0x03, 0x00, 0xCB, 0x02});
-                bodyWriter.Write(new byte[] {0x00, 0x2A});
-                bodyWriter.Write(Guid);
-                bodyWriter.Write(new byte[] {0x04, 0x00, 0x04});
-                bodyWriter.Write(new byte[]
-                {
-                    0x9B, 0x53, 0xB0, 0x08, 0x05, 0x00, 0x04, 0xD9, 0x8A, 0x5A, 0x70, 0x06, 0x00,
-                    0x04, 0x00, 0x00, 0x00, 0x50, 0x07, 0x00, 0x01, 0x43, 0x08, 0x00, 0x00, 0x09, 0x00, 0x01, 0x01,
-                    0x0B,
-                    0x00, 0x00, 0x14, 0x00, 0x04, 0x11, 0x00, 0x00, 0x00, 0x15, 0x00, 0x04, 0x00, 0x00, 0x02, 0xBC,
-                    0x16,
-                    0x00, 0x04, 0x00, 0x00, 0x02, 0xBC, 0x18, 0x00, 0x04, 0x00, 0x00, 0x7D, 0x5E, 0xFF, 0x00, 0x5C,
-                    0x15,
-                    0x36, 0x20, 0x39, 0x32, 0x6B, 0x41, 0x31, 0x43, 0x39, 0x62, 0x35, 0x33, 0x62, 0x30, 0x30, 0x38,
-                    0x64,
-                    0x39, 0x38, 0x61, 0x35, 0x61, 0x37, 0x30
-                });
-                bodyWriter.Write(new byte[]
-                {
-                    0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x35, 0x30, 0x20, 0x20, 0x20, 0x20, 0x20,
-                    0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20
-                });
-                bodyWriter.Write(Guid);
-                bodyWriter.Write(0x41);
-            }
-            else if (_messageType.HasFlag(MessageType.AddGroup))
-            {
-                bodyWriter.Write(new byte[] {0x08});
-                bodyWriter.BEWrite(group);
-                bodyWriter.Write(new byte[] {0x01});
-                bodyWriter.BEWrite((ushort) user.AddFriend_0020Value.Length);
-                bodyWriter.Write(user.AddFriend_0020Value);
-                bodyWriter.Write(new byte[] {0x00, 0x00, 0x00});
-                //备注信息
-                writer.BEWrite((ushort) _message.Length);
-                writer.Write(_message);
-
-                bodyWriter.Write(new byte[] {0x01, 0x00, 0x01, 0x00, 0x04, 0x00, 0x01, 0x00, 0x09});
-            }
-            else if (_messageType.HasFlag(MessageType.GetGroupImformation)) //获取群组信息
-            {
-                bodyWriter.Write(new byte[] {0x72});
-                bodyWriter.BEWrite(group);
-            }
-            else if (_messageType.HasFlag(MessageType.ExitGroup))
-            {
-                bodyWriter.Write(new byte[] {0x09});
-                bodyWriter.BEWrite(group);
-            }
-            else // Send_0x0002是群消息，不需要进行判断
-            {
-                bodyWriter.Write((byte) 0x2A);
-                bodyWriter.BEWrite(group);
-                bodyWriter.BEWrite((ushort) (_message.Length + 56));
-                bodyWriter.Write(new byte[]
-                {
-                    0x00, 0x01, _packetCount, _packetIndex, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x4D, 0x53, 0x47, 0x00,
-                    0x00, 0x00, 0x00, 0x00
-                });
-                bodyWriter.BEWrite(_DateTime);
-                bodyWriter.Write(Util.RandomKey(4));
-                bodyWriter.Write(new byte[] {0x00, 0x00, 0x00, 0x00, 0x09, 0x00, 0x86, 0x00});
-                bodyWriter.Write(new byte[] {0x00, 0x0C});
-                bodyWriter.Write(new byte[] {0xE5, 0xBE, 0xAE, 0xE8, 0xBD, 0xAF, 0xE9, 0x9B, 0x85, 0xE9, 0xBB, 0x91});
-                bodyWriter.Write(new byte[] {0x00, 0x00});
-
-                if (Encoding.UTF8.GetString(_message).Contains("[face") &&
-                    Encoding.UTF8.GetString(_message).Contains(".gif]"))
-                {
-                    var MessageData = ConstructMessage(Encoding.UTF8.GetString(_message));
-                    if (MessageData.Length != 0)
+                    case MessageType.Xml:
                     {
-                        bodyWriter.Write(MessageData);
+                        bodyWriter.Write((byte) 0x2A);
+                        bodyWriter.BEWrite(group);
+                        var compressMsg = GZipByteArray.CompressBytes(snippet.Content);
+                        bodyWriter.BEWrite((ushort) (compressMsg.Length + 64));
+                        bodyWriter.Write(new byte[]
+                        {
+                            0x00, 0x01, _packetCount, _packetIndex, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x4D, 0x53,
+                            0x47, 0x00,
+                            0x00, 0x00, 0x00, 0x00
+                        });
+                        bodyWriter.Write(SendXML(_DateTime, compressMsg));
+                        break;
                     }
-                }
-                else
-                {
-                    //普通消息
-                    ConstructMessage(bodyWriter, _message);
+                    case MessageType.Picture:
+                    {
+                        HttpUpLoadGroupImg(_group, user.Ukey, snippet.Content);
+                        bodyWriter.Write((byte) 0x2A);
+                        bodyWriter.BEWrite(group);
+                        var Guid = Encoding.UTF8.GetBytes(Util.GetMD5ToGuidHashFromFile(snippet.Content));
+                        bodyWriter.Write(new byte[]
+                        {
+                            0x00, 0x01, _packetCount, _packetIndex, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x4D, 0x53,
+                            0x47, 0x00,
+                            0x00, 0x00, 0x00, 0x00
+                        });
+                        bodyWriter.BEWrite(_DateTime);
+                        bodyWriter.Write(Util.RandomKey(4));
+                        bodyWriter.Write(new byte[] {0x00, 0x00, 0x00, 0x00, 0x09, 0x00, 0x86, 0x00});
+                        bodyWriter.Write(new byte[]
+                            {0xE5, 0xBE, 0xAE, 0xE8, 0xBD, 0xAF, 0xE9, 0x9B, 0x85, 0xE9, 0xBB, 0x91});
+                        bodyWriter.Write(new byte[] {0x00, 0x00, 0x03, 0x00, 0xCB, 0x02});
+                        bodyWriter.Write(new byte[] {0x00, 0x2A});
+                        bodyWriter.Write(Guid);
+                        bodyWriter.Write(new byte[] {0x04, 0x00, 0x04});
+                        bodyWriter.Write(new byte[]
+                        {
+                            0x9B, 0x53, 0xB0, 0x08, 0x05, 0x00, 0x04, 0xD9, 0x8A, 0x5A, 0x70, 0x06, 0x00,
+                            0x04, 0x00, 0x00, 0x00, 0x50, 0x07, 0x00, 0x01, 0x43, 0x08, 0x00, 0x00, 0x09, 0x00, 0x01,
+                            0x01,
+                            0x0B,
+                            0x00, 0x00, 0x14, 0x00, 0x04, 0x11, 0x00, 0x00, 0x00, 0x15, 0x00, 0x04, 0x00, 0x00, 0x02,
+                            0xBC,
+                            0x16,
+                            0x00, 0x04, 0x00, 0x00, 0x02, 0xBC, 0x18, 0x00, 0x04, 0x00, 0x00, 0x7D, 0x5E, 0xFF, 0x00,
+                            0x5C,
+                            0x15,
+                            0x36, 0x20, 0x39, 0x32, 0x6B, 0x41, 0x31, 0x43, 0x39, 0x62, 0x35, 0x33, 0x62, 0x30, 0x30,
+                            0x38,
+                            0x64,
+                            0x39, 0x38, 0x61, 0x35, 0x61, 0x37, 0x30
+                        });
+                        bodyWriter.Write(new byte[]
+                        {
+                            0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x35, 0x30, 0x20, 0x20, 0x20, 0x20, 0x20,
+                            0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20
+                        });
+                        bodyWriter.Write(Guid);
+                        bodyWriter.Write(0x41);
+                        break;
+                    }
+                    case MessageType.AddGroup:
+                    {
+                        bodyWriter.Write(new byte[] {0x08});
+                        bodyWriter.BEWrite(group);
+                        bodyWriter.Write(new byte[] {0x01});
+                        bodyWriter.BEWrite((ushort) user.AddFriend_0020Value.Length);
+                        bodyWriter.Write(user.AddFriend_0020Value);
+                        bodyWriter.Write(new byte[] {0x00, 0x00, 0x00});
+                        //备注信息
+                        var _messageData = Encoding.UTF8.GetBytes(snippet.Content);
+                        writer.BEWrite((ushort) _messageData.Length);
+                        writer.Write(_messageData);
+
+                        bodyWriter.Write(new byte[] {0x01, 0x00, 0x01, 0x00, 0x04, 0x00, 0x01, 0x00, 0x09});
+                        break;
+                    }
+                    case MessageType.GetGroupImformation:
+                    {
+                        bodyWriter.Write(new byte[] {0x72});
+                        bodyWriter.BEWrite(group);
+                        break;
+                    }
+                    case MessageType.ExitGroup:
+                    {
+                        bodyWriter.Write(new byte[] {0x09});
+                        bodyWriter.BEWrite(group);
+                        break;
+                    }
+                    case MessageType.Normal:
+                    {
+                        bodyWriter.Write((byte) 0x2A);
+                        bodyWriter.BEWrite(group);
+                        var _messageData = Encoding.UTF8.GetBytes(snippet.Content);
+                        bodyWriter.BEWrite((ushort) (_messageData.Length + 56));
+                        bodyWriter.Write(new byte[]
+                        {
+                            0x00, 0x01, _packetCount, _packetIndex, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x4D, 0x53,
+                            0x47, 0x00,
+                            0x00, 0x00, 0x00, 0x00
+                        });
+                        bodyWriter.BEWrite(_DateTime);
+                        bodyWriter.Write(Util.RandomKey(4));
+                        bodyWriter.Write(new byte[] {0x00, 0x00, 0x00, 0x00, 0x09, 0x00, 0x86, 0x00});
+                        bodyWriter.Write(new byte[] {0x00, 0x0C});
+                        bodyWriter.Write(new byte[]
+                            {0xE5, 0xBE, 0xAE, 0xE8, 0xBD, 0xAF, 0xE9, 0x9B, 0x85, 0xE9, 0xBB, 0x91});
+                        bodyWriter.Write(new byte[] {0x00, 0x00});
+
+                        ConstructMessage(bodyWriter, _messageData);
+                        break;
+                    }
+                    case MessageType.Emoji:
+                    {
+                        bodyWriter.Write((byte) 0x2A);
+                        bodyWriter.BEWrite(group);
+                        var _messageData = Encoding.UTF8.GetBytes(snippet.Content);
+                        bodyWriter.BEWrite((ushort) (_messageData.Length + 56));
+                        bodyWriter.Write(new byte[]
+                        {
+                            0x00, 0x01, _packetCount, _packetIndex, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x4D, 0x53,
+                            0x47, 0x00,
+                            0x00, 0x00, 0x00, 0x00
+                        });
+                        bodyWriter.BEWrite(_DateTime);
+                        bodyWriter.Write(Util.RandomKey(4));
+                        bodyWriter.Write(new byte[] {0x00, 0x00, 0x00, 0x00, 0x09, 0x00, 0x86, 0x00});
+                        bodyWriter.Write(new byte[] {0x00, 0x0C});
+                        bodyWriter.Write(new byte[]
+                            {0xE5, 0xBE, 0xAE, 0xE8, 0xBD, 0xAF, 0xE9, 0x9B, 0x85, 0xE9, 0xBB, 0x91});
+                        bodyWriter.Write(new byte[] {0x00, 0x00});
+                        var MessageData = ConstructMessage(snippet.Content);
+                        if (MessageData.Length != 0)
+                        {
+                            bodyWriter.Write(MessageData);
+                        }
+
+                        break;
+                    }
+                    default:
+                    {
+                        throw new NotImplementedException();
+                    }
                 }
             }
         }
@@ -170,7 +211,8 @@ namespace QQ.Framework.Packets.Send.Message
             using (var webclient = new WebClient())
             {
                 var file = new FileStream(FileName, FileMode.Open);
-                var ApiUrl = $"http://htdata2.qq.com/cgi-bin/httpconn?htcmd=0x6ff0071&ver=5515&term=pc&ukey={Ukey}&filesize={file.Length}&range=0&uin{user.QQ}&&groupcode={GroupNum}";
+                var ApiUrl =
+                    $"http://htdata2.qq.com/cgi-bin/httpconn?htcmd=0x6ff0071&ver=5515&term=pc&ukey={Ukey}&filesize={file.Length}&range=0&uin{user.QQ}&&groupcode={GroupNum}";
                 webclient.Headers["User-Agent"] = "QQClient";
                 webclient.Headers.Add("Content-Type", "application/x-www-form-urlencoded");
                 var result = webclient.UploadData(ApiUrl,
@@ -232,41 +274,9 @@ namespace QQ.Framework.Packets.Send.Message
             return Convert.ToInt64(gid);
         }
 
-        public static List<Send_0x0002> SendLongMessage(QQUser User, string Message, MessageType messageType,
-            long Group)
+        public static List<Send_0x0002> SendLongMessage(QQUser User, Richtext Message, long Group)
         {
-            var buffer = new BinaryWriter(new MemoryStream());
-            var list = new List<byte[]>();
-            foreach (var chr in Message)
-            {
-                var bytes = Encoding.UTF8.GetBytes(chr.ToString());
-                if (buffer.BaseStream.Length + bytes.Length > 699)
-                {
-                    list.Add(buffer.BaseStream.ToBytesArray());
-                    buffer = new BinaryWriter(new MemoryStream());
-                }
-
-                buffer.Write(bytes);
-            }
-
-            if (buffer.BaseStream.Position != 0)
-            {
-                list.Add(buffer.BaseStream.ToBytesArray());
-            }
-
-            byte index = 0;
-            var ret = new List<Send_0x0002>();
-            foreach (var byteBuffer in list)
-            {
-                ret.Add(new Send_0x0002(User, "", messageType, Group)
-                {
-                    _packetCount = (byte) list.Count,
-                    _packetIndex = index++,
-                    _message = byteBuffer
-                });
-            }
-
-            return ret;
+            throw new NotImplementedException();
         }
     }
 }

--- a/QQ.Framework/Packets/Send/Message/Send_0x00CD.cs
+++ b/QQ.Framework/Packets/Send/Message/Send_0x00CD.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Text;
 using QQ.Framework.Utils;
 
@@ -16,7 +15,7 @@ namespace QQ.Framework.Packets.Send.Message
         /// </summary>
         private readonly long _toQQ;
 
-        private byte _packetCount = 1;
+        private readonly byte _packetCount = 1;
         private byte _packetIndex;
 
         public Send_0x00CD(QQUser User, Richtext Message, MessageType messageType, long ToQQ)
@@ -35,7 +34,7 @@ namespace QQ.Framework.Packets.Send.Message
         /// </summary>
         public MessageType _messageType { get; set; }
 
-        private Richtext _message { get; set; }
+        private Richtext _message { get; }
 
         protected override void PutHeader()
         {

--- a/QQ.Framework/Packets/Send/Message/Send_0x00CD.cs
+++ b/QQ.Framework/Packets/Send/Message/Send_0x00CD.cs
@@ -19,13 +19,13 @@ namespace QQ.Framework.Packets.Send.Message
         private byte _packetCount = 1;
         private byte _packetIndex;
 
-        public Send_0x00CD(QQUser User, string Message, MessageType messageType, long ToQQ)
+        public Send_0x00CD(QQUser User, Richtext Message, MessageType messageType, long ToQQ)
             : base(User)
         {
             Sequence = GetNextSeq();
             _secretKey = user.QQ_SessionKey;
             Command = QQCommand.Message0x00CD;
-            _message = Encoding.UTF8.GetBytes(Message);
+            _message = Message;
             _messageType = messageType;
             _toQQ = ToQQ;
         }
@@ -35,7 +35,7 @@ namespace QQ.Framework.Packets.Send.Message
         /// </summary>
         public MessageType _messageType { get; set; }
 
-        private byte[] _message { get; set; }
+        private Richtext _message { get; set; }
 
         protected override void PutHeader()
         {
@@ -50,122 +50,129 @@ namespace QQ.Framework.Packets.Send.Message
         {
             var _DateTime = Util.GetTimeSeconds(DateTime.Now);
             var _Md5 = user.QQ_SessionKey;
-            if (_messageType.HasFlag(MessageType.Xml))
+            foreach (var snippet in _message.Snippets)
             {
-                var compressMsg = GZipByteArray.CompressBytes(Encoding.UTF8.GetString(_message));
-                bodyWriter.BEWrite(user.QQ);
-                bodyWriter.BEWrite(_toQQ);
-                bodyWriter.Write(new byte[] {0x00, 0x00, 0x00, 0x08, 0x00, 0x01, 0x00, 0x04});
-                bodyWriter.Write(new byte[] {0x00, 0x00, 0x00, 0x00});
-                bodyWriter.Write(new byte[] {0x37, 0x0F});
-                bodyWriter.BEWrite(user.QQ);
-                bodyWriter.BEWrite(_toQQ);
-                bodyWriter.Write(_Md5);
-                bodyWriter.Write(new byte[] {0x00, 0x0B});
-                bodyWriter.Write(Util.RandomKey(2));
-                bodyWriter.BEWrite(_DateTime);
-                bodyWriter.Write(new byte[]
+                switch (snippet.Type)
                 {
-                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, _packetCount, _packetIndex, 0x00, 0x00, 0x01, 0x4D, 0x53, 0x47,
-                    0x00, 0x00, 0x00, 0x00, 0x00
-                });
-                bodyWriter.Write(SendXML(_DateTime, compressMsg));
-            }
-            else if (_messageType.HasFlag(MessageType.Shake))
-            {
-                bodyWriter.BEWrite(user.QQ);
-                bodyWriter.BEWrite(_toQQ);
-                bodyWriter.Write(new byte[] {0x00, 0x00, 0x00, 0x00});
-                bodyWriter.Write(new byte[] {0x37, 0x0F});
-                bodyWriter.BEWrite(user.QQ);
-                bodyWriter.BEWrite(_toQQ);
-                bodyWriter.Write(Util.RandomKey());
-                bodyWriter.Write(new byte[] {0x00, 0xAF});
-                bodyWriter.Write(Util.RandomKey(2));
-                bodyWriter.BEWrite(_DateTime);
-                bodyWriter.Write(new byte[] {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
-                bodyWriter.Write(Util.RandomKey(4));
-                bodyWriter.Write(new byte[] {0x00, 0x00, 0x00, 0x00});
-            }
-            else
-            {
-                bodyWriter.BEWrite(user.QQ);
-                bodyWriter.BEWrite(_toQQ);
-                bodyWriter.Write(new byte[]
-                {
-                    0x00, 0x00, 0x00, 0x0D, 0x00, 0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x01, 0x01
-                });
-                bodyWriter.Write(new byte[] {0x36, 0x43});
-                bodyWriter.BEWrite(user.QQ);
-                bodyWriter.BEWrite(_toQQ);
-                bodyWriter.Write(_Md5);
-                bodyWriter.Write(new byte[] {0x00, 0x0B});
-                bodyWriter.Write(Util.RandomKey(2));
-                bodyWriter.BEWrite(_DateTime);
-                bodyWriter.Write(new byte[]
-                {
-                    0x02, 0x34, 0x00, 0x00, 0x00, 0x00, _packetCount, _packetIndex, 0x00, 0x00, 0x01, 0x4D, 0x53, 0x47,
-                    0x00, 0x00, 0x00, 0x00, 0x00
-                });
-                bodyWriter.BEWrite(_DateTime);
-                bodyWriter.Write(Util.RandomKey(4));
-                bodyWriter.Write(new byte[] {0x00, 0x00, 0x00, 0x00, 0x09, 0x00, 0x86, 0x00});
-                bodyWriter.Write(new byte[] {0x00, 0x06});
-                bodyWriter.Write(new byte[] {0xE5, 0xAE, 0x8B, 0xE4, 0xBD, 0x93});
-                bodyWriter.Write(new byte[] {0x00, 0x00});
-
-                if (Encoding.UTF8.GetString(_message).Contains("[face") &&
-                    Encoding.UTF8.GetString(_message).Contains(".gif]"))
-                {
-                    var MessageData = ConstructMessage(Encoding.UTF8.GetString(_message));
-                    if (MessageData.Length != 0)
+                    case MessageType.Xml:
                     {
-                        bodyWriter.Write(MessageData);
+                        var compressMsg = GZipByteArray.CompressBytes(snippet.Content);
+                        bodyWriter.BEWrite(user.QQ);
+                        bodyWriter.BEWrite(_toQQ);
+                        bodyWriter.Write(new byte[] {0x00, 0x00, 0x00, 0x08, 0x00, 0x01, 0x00, 0x04});
+                        bodyWriter.Write(new byte[] {0x00, 0x00, 0x00, 0x00});
+                        bodyWriter.Write(new byte[] {0x37, 0x0F});
+                        bodyWriter.BEWrite(user.QQ);
+                        bodyWriter.BEWrite(_toQQ);
+                        bodyWriter.Write(_Md5);
+                        bodyWriter.Write(new byte[] {0x00, 0x0B});
+                        bodyWriter.Write(Util.RandomKey(2));
+                        bodyWriter.BEWrite(_DateTime);
+                        bodyWriter.Write(new byte[]
+                        {
+                            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, _packetCount, _packetIndex, 0x00, 0x00, 0x01, 0x4D,
+                            0x53, 0x47,
+                            0x00, 0x00, 0x00, 0x00, 0x00
+                        });
+                        bodyWriter.Write(SendXML(_DateTime, compressMsg));
+                        break;
                     }
-                }
-                else
-                {
-                    //普通消息
-                    ConstructMessage(bodyWriter, _message);
+                    case MessageType.Shake:
+                    {
+                        bodyWriter.BEWrite(user.QQ);
+                        bodyWriter.BEWrite(_toQQ);
+                        bodyWriter.Write(new byte[] {0x00, 0x00, 0x00, 0x00});
+                        bodyWriter.Write(new byte[] {0x37, 0x0F});
+                        bodyWriter.BEWrite(user.QQ);
+                        bodyWriter.BEWrite(_toQQ);
+                        bodyWriter.Write(Util.RandomKey());
+                        bodyWriter.Write(new byte[] {0x00, 0xAF});
+                        bodyWriter.Write(Util.RandomKey(2));
+                        bodyWriter.BEWrite(_DateTime);
+                        bodyWriter.Write(new byte[] {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+                        bodyWriter.Write(Util.RandomKey(4));
+                        bodyWriter.Write(new byte[] {0x00, 0x00, 0x00, 0x00});
+                        break;
+                    }
+                    case MessageType.Normal:
+                    {
+                        bodyWriter.BEWrite(user.QQ);
+                        bodyWriter.BEWrite(_toQQ);
+                        bodyWriter.Write(new byte[]
+                        {
+                            0x00, 0x00, 0x00, 0x0D, 0x00, 0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00,
+                            0x01, 0x01
+                        });
+                        bodyWriter.Write(new byte[] {0x36, 0x43});
+                        bodyWriter.BEWrite(user.QQ);
+                        bodyWriter.BEWrite(_toQQ);
+                        bodyWriter.Write(_Md5);
+                        bodyWriter.Write(new byte[] {0x00, 0x0B});
+                        bodyWriter.Write(Util.RandomKey(2));
+                        bodyWriter.BEWrite(_DateTime);
+                        bodyWriter.Write(new byte[]
+                        {
+                            0x02, 0x34, 0x00, 0x00, 0x00, 0x00, _packetCount, _packetIndex, 0x00, 0x00, 0x01, 0x4D,
+                            0x53, 0x47,
+                            0x00, 0x00, 0x00, 0x00, 0x00
+                        });
+                        bodyWriter.BEWrite(_DateTime);
+                        bodyWriter.Write(Util.RandomKey(4));
+                        bodyWriter.Write(new byte[] {0x00, 0x00, 0x00, 0x00, 0x09, 0x00, 0x86, 0x00});
+                        bodyWriter.Write(new byte[] {0x00, 0x06});
+                        bodyWriter.Write(new byte[] {0xE5, 0xAE, 0x8B, 0xE4, 0xBD, 0x93});
+                        bodyWriter.Write(new byte[] {0x00, 0x00});
+                        var _messageData = Encoding.UTF8.GetBytes(snippet.Content);
+                        ConstructMessage(bodyWriter, _messageData);
+                        break;
+                    }
+                    case MessageType.Emoji:
+                    {
+                        bodyWriter.BEWrite(user.QQ);
+                        bodyWriter.BEWrite(_toQQ);
+                        bodyWriter.Write(new byte[]
+                        {
+                            0x00, 0x00, 0x00, 0x0D, 0x00, 0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00,
+                            0x01, 0x01
+                        });
+                        bodyWriter.Write(new byte[] {0x36, 0x43});
+                        bodyWriter.BEWrite(user.QQ);
+                        bodyWriter.BEWrite(_toQQ);
+                        bodyWriter.Write(_Md5);
+                        bodyWriter.Write(new byte[] {0x00, 0x0B});
+                        bodyWriter.Write(Util.RandomKey(2));
+                        bodyWriter.BEWrite(_DateTime);
+                        bodyWriter.Write(new byte[]
+                        {
+                            0x02, 0x34, 0x00, 0x00, 0x00, 0x00, _packetCount, _packetIndex, 0x00, 0x00, 0x01, 0x4D,
+                            0x53, 0x47,
+                            0x00, 0x00, 0x00, 0x00, 0x00
+                        });
+                        bodyWriter.BEWrite(_DateTime);
+                        bodyWriter.Write(Util.RandomKey(4));
+                        bodyWriter.Write(new byte[] {0x00, 0x00, 0x00, 0x00, 0x09, 0x00, 0x86, 0x00});
+                        bodyWriter.Write(new byte[] {0x00, 0x06});
+                        bodyWriter.Write(new byte[] {0xE5, 0xAE, 0x8B, 0xE4, 0xBD, 0x93});
+                        bodyWriter.Write(new byte[] {0x00, 0x00});
+                        var MessageData = ConstructMessage(snippet.Content);
+                        if (MessageData.Length != 0)
+                        {
+                            bodyWriter.Write(MessageData);
+                        }
+
+                        break;
+                    }
+                    default:
+                    {
+                        throw new NotImplementedException();
+                    }
                 }
             }
         }
 
-        public static List<Send_0x00CD> SendLongMessage(QQUser User, string Message, MessageType messageType,
-            long ToQQ)
+        public static List<Send_0x00CD> SendLongMessage(QQUser User, Richtext Message, long ToQQ)
         {
-            var buffer = new BinaryWriter(new MemoryStream());
-            var list = new List<byte[]>();
-            foreach (var chr in Message)
-            {
-                var bytes = Encoding.UTF8.GetBytes(chr.ToString());
-                if (buffer.BaseStream.Length + bytes.Length > 699)
-                {
-                    list.Add(buffer.BaseStream.ToBytesArray());
-                    buffer = new BinaryWriter(new MemoryStream());
-                }
-
-                buffer.Write(bytes);
-            }
-
-            if (buffer.BaseStream.Position != 0)
-            {
-                list.Add(buffer.BaseStream.ToBytesArray());
-            }
-
-            byte index = 0;
-            var ret = new List<Send_0x00CD>();
-            foreach (var byteBuffer in list)
-            {
-                ret.Add(new Send_0x00CD(User, "", messageType, ToQQ)
-                {
-                    _packetCount = (byte) list.Count,
-                    _packetIndex = index++,
-                    _message = byteBuffer
-                });
-            }
-
-            return ret;
+            throw new NotImplementedException();
         }
     }
 }

--- a/QQ.Framework/Packets/Send/Message/Send_0x0352.cs
+++ b/QQ.Framework/Packets/Send/Message/Send_0x0352.cs
@@ -1,16 +1,15 @@
-using QQ.Framework.Utils;
-using System;
 using System.Drawing;
 using System.IO;
+using QQ.Framework.Utils;
 
 namespace QQ.Framework.Packets.Send.Message
 {
     /// <summary>
-    /// 私聊图片获取Ukey
+    ///     私聊图片获取Ukey
     /// </summary>
     public class Send_0x0352 : SendPacket
     {
-        public Send_0x0352(QQUser User,string FileName,long ToQQ)
+        public Send_0x0352(QQUser User, string FileName, long ToQQ)
             : base(User)
         {
             Sequence = GetNextSeq();
@@ -20,63 +19,71 @@ namespace QQ.Framework.Packets.Send.Message
             _toQQ = ToQQ;
         }
 
+        public string fileName { get; set; }
+        public long _toQQ { get; set; }
+
         protected override void PutHeader()
         {
             base.PutHeader();
             //writer.Write(user.QQ_PACKET_FIXVER);
-            writer.Write(new byte[] {
-                0x04,0x00,0x00,0x00,0x01,0x01,0x01,0x00,0x00,0x68,
-                0x1C,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
+            writer.Write(new byte[]
+            {
+                0x04, 0x00, 0x00, 0x00, 0x01, 0x01, 0x01, 0x00, 0x00, 0x68,
+                0x1C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
             });
         }
-        public string fileName { get; set; }
-        public long _toQQ { get; set; }
+
         /// <summary>
         ///     初始化包体
         /// </summary>
         protected override void PutBody()
         {
-            Bitmap pic = new Bitmap(fileName);
-            int Width = pic.Size.Width; // 图片的宽度
-            int Height = pic.Size.Height; // 图片的高度
+            var pic = new Bitmap(fileName);
+            var Width = pic.Size.Width; // 图片的宽度
+            var Height = pic.Size.Height; // 图片的高度
             var picBytes = ImageHelper.ImageToBytes(pic);
             var Md5 = QQTea.MD5(picBytes);
 
-            BinaryWriter _Data = new BinaryWriter(new MemoryStream());
-            _Data.Write(new byte[]{
-                 0x01, 0x08, 0x01, 0x12
+            var _Data = new BinaryWriter(new MemoryStream());
+            _Data.Write(new byte[]
+            {
+                0x01, 0x08, 0x01, 0x12
             });
-            _Data.Write((byte)0x5A);
-            _Data.Write((byte)0x08);
+            _Data.Write((byte) 0x5A);
+            _Data.Write((byte) 0x08);
             _Data.Write(Util.HexStringToByteArray(Util.PB_toLength(user.QQ)));
-            _Data.Write((byte)0x10);
+            _Data.Write((byte) 0x10);
             _Data.Write(Util.HexStringToByteArray(Util.PB_toLength(_toQQ)));
-            _Data.BEWrite((ushort)0x1800);
-            _Data.Write((byte)0x22);
-            _Data.Write((byte)0x10);
+            _Data.BEWrite((ushort) 0x1800);
+            _Data.Write((byte) 0x22);
+            _Data.Write((byte) 0x10);
             _Data.Write(Md5);
-            _Data.Write((byte)0x28);
+            _Data.Write((byte) 0x28);
             _Data.Write(Util.HexStringToByteArray(Util.PB_toLength(picBytes.Length)));
-            _Data.Write((byte)0x32);
-            _Data.Write((byte)0x1A);
-            _Data.Write(new byte[]{
+            _Data.Write((byte) 0x32);
+            _Data.Write((byte) 0x1A);
+            _Data.Write(new byte[]
+            {
                 0x57, 0x00, 0x53, 0x00, 0x4E, 0x00, 0x53, 0x00, 0x4C, 0x00, 0x54, 0x00,
                 0x31, 0x00, 0x36, 0x00, 0x47, 0x00, 0x45, 0x00, 0x4F, 0x00, 0x5B, 0x00,
-                0x5F, 0x00 });
-            _Data.BEWrite((ushort)0x3801);
-            _Data.BEWrite((ushort)0x4801);
-            _Data.Write((byte)0x70);
+                0x5F, 0x00
+            });
+            _Data.BEWrite((ushort) 0x3801);
+            _Data.BEWrite((ushort) 0x4801);
+            _Data.Write((byte) 0x70);
             _Data.Write(Util.HexStringToByteArray(Util.PB_toLength(Width)));
-            _Data.Write((byte)0x78);
+            _Data.Write((byte) 0x78);
             _Data.Write(Util.HexStringToByteArray(Util.PB_toLength(Height)));
 
-            bodyWriter.Write(new byte[]{
+            bodyWriter.Write(new byte[]
+            {
                 0x00, 0x00, 0x00, 0x07
             });
             //数据长度
             bodyWriter.BEWrite(_Data.BaseStream.Length);
-            bodyWriter.Write(new byte[]{
-                 0x08, 0x01, 0x12, 0x03, 0x98, 0x01
+            bodyWriter.Write(new byte[]
+            {
+                0x08, 0x01, 0x12, 0x03, 0x98, 0x01
             });
             //数据
             bodyWriter.Write(_Data.BaseStream.ToBytesArray());

--- a/QQ.Framework/QQClient.cs
+++ b/QQ.Framework/QQClient.cs
@@ -356,9 +356,9 @@ namespace QQ.Framework
         /// <param name="e"></param>
         internal void OnReceive_0x00CE(QQEventArgs<Receive_0x00CE> e)
         {
-            if (!string.IsNullOrEmpty(e.ReceivePacket.Message))
+            if (!string.IsNullOrEmpty(e.ReceivePacket.Message.ToString()))
             {
-                if (!QQGlobal.DebugLog && e.ReceivePacket.Message.Count(c => c == '\0') > 5)
+                if (!QQGlobal.DebugLog && e.ReceivePacket.Message.ToString().Count(c => c == '\0') > 5)
                 {
                     QQUser.MessageLog($"收到好友{e.ReceivePacket.FromQQ}的乱码消息。");
                     //return;

--- a/QQ.Framework/QQClient.cs
+++ b/QQ.Framework/QQClient.cs
@@ -521,10 +521,9 @@ namespace QQ.Framework
         /// <param name="message"></param>
         /// <param name="group"></param>
         /// <param name="MessageType">消息类型</param>
-        public void SendLongGroupMessage(string message, long group, MessageType MessageType)
+        public void SendLongGroupMessage(Richtext message, long group)
         {
-            message = message.Replace("\n", "\r").Trim();
-            foreach (var packet in Send_0x0002.SendLongMessage(QQUser, message, MessageType, group))
+            foreach (var packet in Send_0x0002.SendLongMessage(QQUser, message, group))
             {
                 Send(packet.WriteData());
             }
@@ -536,10 +535,9 @@ namespace QQ.Framework
         /// <param name="message"></param>
         /// <param name="user"></param>
         /// <param name="MessageType">消息类型</param>
-        public void SendLongUserMessage(string message, long user, MessageType MessageType)
+        public void SendLongUserMessage(Richtext message, long user)
         {
-            message = message.Replace("\n", "\r").Trim();
-            foreach (var packet in Send_0x00CD.SendLongMessage(QQUser, message, MessageType, user))
+            foreach (var packet in Send_0x00CD.SendLongMessage(QQUser, message, user))
             {
                 Send(packet.WriteData());
             }

--- a/QQ.Framework/QQGlobal.cs
+++ b/QQ.Framework/QQGlobal.cs
@@ -365,49 +365,58 @@ namespace QQ.Framework
         /// </summary>
         Unknown = 0xFFFF
     }
-
-    [Flags]
+    
     public enum MessageType
     {
         /// <summary>
         ///     普通文本
         /// </summary>
-        Normal = 1,
+        Normal,
 
         /// <summary>
         ///     抖动
         /// </summary>
-        Shake = 2,
+        Shake,
+
+        /// <summary>
+        ///     系统表情
+        /// </summary>
+        Emoji,
 
         /// <summary>
         ///     图片消息
         /// </summary>
-        Picture = 4,
+        Picture,
 
         /// <summary>
         ///     Xml消息
         /// </summary>
-        Xml = 8,
+        Xml,
 
         /// <summary>
         ///     Json消息
         /// </summary>
-        Json = 16,
+        Json,
 
         /// <summary>
         ///     退群
         /// </summary>
-        ExitGroup = 32,
+        ExitGroup,
 
         /// <summary>
         ///     获取群信息
         /// </summary>
-        GetGroupImformation = 64,
+        GetGroupImformation,
 
         /// <summary>
         ///     加群
         /// </summary>
-        AddGroup = 128
+        AddGroup,
+
+        /// <summary>
+        ///     @他人
+        /// </summary>
+        At
     }
 
     public static class LoginStatus

--- a/QQ.Framework/QQGlobal.cs
+++ b/QQ.Framework/QQGlobal.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace QQ.Framework
 {
     /// <summary>
@@ -345,8 +343,9 @@ namespace QQ.Framework
         ///     获取Ukey
         /// </summary>
         Message0x0352 = 0x0352,
+
         /// <summary>
-        /// 获取Ukey
+        ///     获取Ukey
         /// </summary>
         Message0x0388 = 0x0388,
 
@@ -365,7 +364,7 @@ namespace QQ.Framework
         /// </summary>
         Unknown = 0xFFFF
     }
-    
+
     public enum MessageType
     {
         /// <summary>

--- a/QQ.Framework/Sockets/MessageManage.cs
+++ b/QQ.Framework/Sockets/MessageManage.cs
@@ -1,11 +1,6 @@
-using System.Net;
-using System.Net.Sockets;
 using System.Threading;
 using QQ.Framework.Domains;
 using QQ.Framework.Packets;
-using QQ.Framework.Packets.Receive.Data;
-using QQ.Framework.Packets.Receive.Login;
-using QQ.Framework.Packets.Receive.Message;
 using QQ.Framework.Utils;
 
 namespace QQ.Framework.Sockets
@@ -28,7 +23,7 @@ namespace QQ.Framework.Sockets
         /// <summary>
         ///     消息转发器
         /// </summary>
-        private ServerMessageSubject _transponder;
+        private readonly ServerMessageSubject _transponder;
 
         public MessageManage(SocketService service, QQUser user, ServerMessageSubject transponder)
         {

--- a/QQ.Framework/Utils/DispatchPacketToCommand.cs
+++ b/QQ.Framework/Utils/DispatchPacketToCommand.cs
@@ -14,7 +14,8 @@ namespace QQ.Framework.Utils
         private readonly ServerMessageSubject _transponder;
         private readonly QQUser _user;
 
-        protected DispatchPacketToCommand(byte[] data, SocketService service, ServerMessageSubject transponder, QQUser user)
+        protected DispatchPacketToCommand(byte[] data, SocketService service, ServerMessageSubject transponder,
+            QQUser user)
         {
             _data = data;
             _service = service;
@@ -22,7 +23,8 @@ namespace QQ.Framework.Utils
             _user = user;
         }
 
-        public static DispatchPacketToCommand Of(byte[] data, SocketService service, ServerMessageSubject transponder, QQUser user)
+        public static DispatchPacketToCommand Of(byte[] data, SocketService service, ServerMessageSubject transponder,
+            QQUser user)
         {
             return new DispatchPacketToCommand(data, service, transponder, user);
         }
@@ -41,7 +43,8 @@ namespace QQ.Framework.Utils
                 var attribute = attributes.First(attr => attr is ReceivePacketCommand) as ReceivePacketCommand;
                 if (attribute.Command == command)
                 {
-                    var receive_packet = Activator.CreateInstance(type, _data, _service, _transponder, _user) as PacketCommand;
+                    var receive_packet =
+                        Activator.CreateInstance(type, _data, _service, _transponder, _user) as PacketCommand;
                     return receive_packet;
                 }
             }

--- a/QQ.Framework/Utils/ResponsePacketProcessor.cs
+++ b/QQ.Framework/Utils/ResponsePacketProcessor.cs
@@ -47,7 +47,8 @@ namespace QQ.Framework.Utils
                 }
             }
 
-            return new DefaultResponseCommand(new QQEventArgs<ReceivePacket>(_args.Service, _args.User, _args.ReceivePacket));
+            return new DefaultResponseCommand(new QQEventArgs<ReceivePacket>(_args.Service, _args.User,
+                _args.ReceivePacket));
         }
 
         public static ResponsePacketProcessor<PacketType> of(QQEventArgs<PacketType> args, Type receivePacketType)

--- a/QQ.Framework/Utils/Richtext.cs
+++ b/QQ.Framework/Utils/Richtext.cs
@@ -12,7 +12,7 @@ namespace QQ.Framework.Utils
             {
                 Snippets = new List<TextSnippet>
                 {
-                    new TextSnippet {Content = message}
+                    new TextSnippet {Content = message ?? ""}
                 }
             };
         }

--- a/QQ.Framework/Utils/Richtext.cs
+++ b/QQ.Framework/Utils/Richtext.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+
+namespace QQ.Framework.Utils
+{
+    public class Richtext
+    {
+        public List<TextSnippet> Snippets = new List<TextSnippet>();
+
+        public static Richtext FromLiteral(string message)
+        {
+            return new Richtext
+            {
+                Snippets = new List<TextSnippet>
+                {
+                    new TextSnippet {Content = message}
+                }
+            };
+        }
+
+        public override string ToString()
+        {
+            return string.Join("", Snippets);
+        }
+    }
+
+    public class TextSnippet
+    {
+        public string Content;
+        public MessageType Type;
+
+        public override string ToString()
+        {
+            switch (Type)
+            {
+                case MessageType.Normal:
+                    return Content;
+                case MessageType.Shake:
+                    return "[窗口抖动]";
+                case MessageType.Picture:
+                    return $"[图片{Content}]";
+                case MessageType.Xml:
+                    return $"[XML代码{Content}]";
+                case MessageType.Json:
+                    return $"[JSON代码{Content}]";
+                case MessageType.Emoji:
+                    return $"[表情{Content}]";
+                case MessageType.At:
+                    return $"[@{Content}]";
+                default:
+                    return "[特殊代码]";
+            }
+        }
+    }
+}

--- a/QQ.FrameworkTest/Robots/TestRoBot.cs
+++ b/QQ.FrameworkTest/Robots/TestRoBot.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using QQ.Framework;
 using QQ.Framework.Domains;
+using QQ.Framework.Utils;
 
 namespace QQ.FrameworkTest.Robots
 {
@@ -10,12 +11,12 @@ namespace QQ.FrameworkTest.Robots
         {
         }
 
-        public override void ReceiveFriendMessage(long friendNumber, string content)
+        public override void ReceiveFriendMessage(long friendNumber, Richtext content)
         {
             Console.WriteLine($"机器人收到来自{friendNumber}的消息{content}");
         }
 
-        public override void ReceiveGroupMessage(long groupNumber, long fromNumber, string content)
+        public override void ReceiveGroupMessage(long groupNumber, long fromNumber, Richtext content)
         {
         }
     }

--- a/QQLoginTest/Program.cs
+++ b/QQLoginTest/Program.cs
@@ -27,7 +27,7 @@ namespace QQLoginTest
             var user = new QQUser(MyQQ, MyPassWord);
             var socketServer = new SocketServiceImpl(user);
             var transponder = new Transponder();
-            var sendService = new SendMessageServiceImpl(socketServer);
+            var sendService = new SendMessageServiceImpl(socketServer, user);
 
             var manage = new MessageManage(socketServer, user, transponder);
 


### PR DESCRIPTION
从string变为Util.Richtext，可以在同一条信息中含有图片、表情（emoji）、文本和@。
暂时失去长消息（超过700字节的文本）支持。 