### PR TITLE
Feature add login fail callback

### DIFF
--- a/QQ.Framework/Domains/Commands/ReceiveCommands/Login/GetTGTGTCommand.cs
+++ b/QQ.Framework/Domains/Commands/ReceiveCommands/Login/GetTGTGTCommand.cs
@@ -17,12 +17,7 @@ namespace QQ.Framework.Domains.Commands.ReceiveCommands.Login
         {
             if (_packet.Result != (byte) ResultCode.成功)
             {
-		// _service.MessageLog(_packet.ErrorMsg);
-		if(_packet.Result != (byte) ResultCode.需要更新TGTGT
-		   && _packet.Result != (byte) ResultCode.需要重新CheckTGTGT) {
-		    // 忽略二次登录
-		    _service.LoginCallback(false, _packet.ErrorMsg);
-		}
+		_service.MessageLog(_packet.ErrorMsg);
             }
 
             Response();

--- a/QQ.Framework/Domains/Commands/ReceiveCommands/Login/GetTGTGTCommand.cs
+++ b/QQ.Framework/Domains/Commands/ReceiveCommands/Login/GetTGTGTCommand.cs
@@ -17,7 +17,7 @@ namespace QQ.Framework.Domains.Commands.ReceiveCommands.Login
         {
             if (_packet.Result != (byte) ResultCode.成功)
             {
-		_service.MessageLog(_packet.ErrorMsg);
+                _service.MessageLog(_packet.ErrorMsg);
             }
 
             Response();

--- a/QQ.Framework/Domains/Commands/ReceiveCommands/Login/GetTGTGTCommand.cs
+++ b/QQ.Framework/Domains/Commands/ReceiveCommands/Login/GetTGTGTCommand.cs
@@ -17,7 +17,12 @@ namespace QQ.Framework.Domains.Commands.ReceiveCommands.Login
         {
             if (_packet.Result != (byte) ResultCode.成功)
             {
-                _service.MessageLog(_packet.ErrorMsg);
+		// _service.MessageLog(_packet.ErrorMsg);
+		if(_packet.Result != (byte) ResultCode.需要更新TGTGT
+		   && _packet.Result != (byte) ResultCode.需要重新CheckTGTGT) {
+		    // 忽略二次登录
+		    _service.LoginCallback(false, _packet.ErrorMsg);
+		}
             }
 
             Response();

--- a/QQ.Framework/Domains/Commands/ResponseCommands/Login/LoginVerifyCommand.cs
+++ b/QQ.Framework/Domains/Commands/ResponseCommands/Login/LoginVerifyCommand.cs
@@ -33,7 +33,10 @@ namespace QQ.Framework.Domains.Commands.ResponseCommands.Login
                 _service.Send(new Send_0X0828(_user));
 
 		_service.LoginCallback(true, "");
-            }
+            } else {
+		// 未处理的登录失败，通知应用层
+		_service.LoginCallback(false, _packet.ErrorMsg);
+	    }
         }
     }
 }

--- a/QQ.Framework/Domains/Commands/ResponseCommands/Login/LoginVerifyCommand.cs
+++ b/QQ.Framework/Domains/Commands/ResponseCommands/Login/LoginVerifyCommand.cs
@@ -31,6 +31,8 @@ namespace QQ.Framework.Domains.Commands.ResponseCommands.Login
                 _service.MessageLog("登陆成功获取个人基本信息");
                 _service.MessageLog($"账号：{_user.QQ}，昵称：{_user.NickName}，年龄：{_user.Age}，性别：{_user.Gender}");
                 _service.Send(new Send_0X0828(_user));
+
+		_service.LoginCallback(true, "");
             }
         }
     }

--- a/QQ.Framework/Domains/SocketService.cs
+++ b/QQ.Framework/Domains/SocketService.cs
@@ -36,9 +36,18 @@ namespace QQ.Framework.Domains
         void Login();
 
         /// <summary>
+        ///     处理登录结果
+        /// </summary>
+	/// <param name="isSuccess">是否成功</param>
+	/// <param name="message">消息</param>
+        void LoginCallback(bool isSuccess, string message);
+
+        /// <summary>
         ///     接收验证码
         /// </summary>
         /// <param name="data"></param>
         void ReceiveVerifyCode(byte[] data);
+
+	
     }
 }

--- a/QQ.Framework/Domains/SocketService.cs
+++ b/QQ.Framework/Domains/SocketService.cs
@@ -38,8 +38,8 @@ namespace QQ.Framework.Domains
         /// <summary>
         ///     处理登录结果
         /// </summary>
-	/// <param name="isSuccess">是否成功</param>
-	/// <param name="message">消息</param>
+        /// <param name="isSuccess">是否成功</param>
+        /// <param name="message">消息</param>
         void LoginCallback(bool isSuccess, string message);
 
         /// <summary>
@@ -47,7 +47,5 @@ namespace QQ.Framework.Domains
         /// </summary>
         /// <param name="data"></param>
         void ReceiveVerifyCode(byte[] data);
-
-	
     }
 }

--- a/QQ.Framework/Domains/SocketServiceImpl.cs
+++ b/QQ.Framework/Domains/SocketServiceImpl.cs
@@ -76,6 +76,14 @@ namespace QQ.Framework.Domains
             MessageLog($"登录服务器{_host}");
         }
 
+        public void LoginCallback(bool isSuccess, string message) {
+	    if(isSuccess) {
+		MessageLog($"登录成功: {message}");
+	    } else {
+		MessageLog($"登录失败: {message}");
+	    }
+	}
+
         public void ReceiveVerifyCode(byte[] data)
         {
             var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "yanzhengma");

--- a/QQ.Framework/Domains/SocketServiceImpl.cs
+++ b/QQ.Framework/Domains/SocketServiceImpl.cs
@@ -77,12 +77,12 @@ namespace QQ.Framework.Domains
         }
 
         public void LoginCallback(bool isSuccess, string message) {
-	    if(isSuccess) {
-		MessageLog($"登录成功: {message}");
-	    } else {
-		MessageLog($"登录失败: {message}");
-	    }
-	}
+            if(isSuccess) {
+        	MessageLog($"登录成功: {message}");
+            } else {
+        	MessageLog($"登录失败: {message}");
+            }
+        }
 
         public void ReceiveVerifyCode(byte[] data)
         {


### PR DESCRIPTION
在SocketService中增加了 LoginCallback接口，在LoginVerifyCommand中对登录成功和失败分别调用该接口，通知上层应用，需要验证码、二次登录等情形则不调用该接口。验证码已经有ReceiveVerifyCode接口来通知，二次登录则可对上层应用透明。